### PR TITLE
CE-240 sh.addShard() fails if staging DB password contains special characters.

### DIFF
--- a/src/libs/mongodb_lib/MongoDB.py
+++ b/src/libs/mongodb_lib/MongoDB.py
@@ -2,6 +2,7 @@ import json
 
 from mongodb_lib.constants import MongoDBLibConstants
 from ce_lib import helpers
+import urllib.parse
 
 
 class MongoDB:
@@ -337,13 +338,8 @@ class MongoDB:
         :return: Standard connection string
         :rtype: ``str``
         """
-        percent_encoding_dict = MongoDBLibConstants.STANDARD_CONN_STRING_ENCODING
-        encoded_username = "".join(
-            [percent_encoding_dict[s] if s in percent_encoding_dict else s for s
-             in username])
-        encoded_password = "".join(
-            [percent_encoding_dict[s] if s in percent_encoding_dict else s for s
-             in password])
+        encoded_username = urllib.parse.quote(username)
+        encoded_password = urllib.parse.quote(password)
 
         host_param_dict = helpers.parse_shell_params(host_conn_string)
 

--- a/src/libs/mongodb_lib/constants.py
+++ b/src/libs/mongodb_lib/constants.py
@@ -17,14 +17,6 @@ class MongoDBLibConstants:
 
     CLUSTERSYNC_RESERVED_DATABASE = "mongosync_reserved_for_internal_use"
 
-    STANDARD_CONN_STRING_ENCODING = {":": "%3A",
-                                "/": "%2F",
-                                "?": "%3F",
-                                "#": "%23",
-                                "[": "%5B",
-                                "]": "%5D",
-                                "@": "%40"
-                                     }
     #standard_conn_string_format = "mongodb://{username}:{password}@{host_conn_string}?{additional_auth_params}/{database}"
     STANDARD_CONN_STRING_FORMAT = "mongodb://{username}:{password}@{host_conn_string}/{database}?{additional_auth_params}"
 


### PR DESCRIPTION
sh.addShard() fails if staging DB password contains special characters.